### PR TITLE
Add post-deploy triage flow to render-deploy

### DIFF
--- a/skills/render-deploy/SKILL.md
+++ b/skills/render-deploy/SKILL.md
@@ -394,7 +394,7 @@ get_metrics(
 )
 ```
 
-If errors are found, use the **debug** skill to diagnose and fix issues.
+If errors are found, proceed to the **Post-deploy verification and basic triage** section below.
 
 ---
 
@@ -447,3 +447,22 @@ Check deploy status, logs, and metrics. See [references/direct-creation.md](refe
 ---
 
 For service discovery, configuration details, quick commands, and common issues, see [references/deployment-details.md](references/deployment-details.md).
+
+---
+
+# Post-deploy verification and basic triage (All Methods)
+
+Keep this short and repeatable. If any check fails, fix it before redeploying.
+
+1. Confirm the latest deploy is `live` and serving traffic
+2. Hit the health endpoint (or root) and verify a 200 response
+3. Scan recent error logs for a clear failure signature
+4. Verify required env vars and port binding (`0.0.0.0:$PORT`)
+
+Detailed checklist and commands: [references/post-deploy-checks.md](references/post-deploy-checks.md)
+
+If the service fails to start or health checks time out, use the basic triage guide:
+[references/troubleshooting-basics.md](references/troubleshooting-basics.md)
+
+Optional: If you need deeper diagnostics (metrics/DB checks/error catalog), suggest installing the
+`render-debug` skill. It is not required for the core deploy flow.

--- a/skills/render-deploy/references/error-patterns.md
+++ b/skills/render-deploy/references/error-patterns.md
@@ -1,0 +1,13 @@
+# Error patterns (compact)
+
+Use this to quickly map log signatures to likely causes and fixes.
+
+| Log pattern | Likely cause | Quick fix |
+| --- | --- | --- |
+| `KeyError`, `not defined`, `missing environment` | Missing env var | Add env var in render.yaml or via MCP, then redeploy |
+| `EADDRINUSE`, `listen EADDRINUSE` | Port binding conflict | Bind to `0.0.0.0:$PORT` |
+| `Cannot find module`, `ModuleNotFoundError` | Missing dependency | Add dependency to manifest and rebuild |
+| `ECONNREFUSED`, `connection refused` | DB not reachable | Verify DATABASE_URL and DB status |
+| `Health check timeout` | No healthy response | Add/verify health endpoint and port |
+| `exit 137`, `out of memory` | OOM | Reduce memory use or upgrade plan |
+| `Command failed`, `build failed` | Bad build command | Fix build command or dependencies |

--- a/skills/render-deploy/references/post-deploy-checks.md
+++ b/skills/render-deploy/references/post-deploy-checks.md
@@ -1,0 +1,36 @@
+# Post-deploy checks
+
+Use this after any deploy or service creation. Keep it short; stop when a check fails.
+
+## 1) Confirm deploy status
+
+```
+list_deploys(serviceId: "<service-id>", limit: 1)
+```
+
+- Expect `status: "live"`.
+- If status is failed, inspect build/runtime logs immediately.
+
+## 2) Verify service health
+
+- Hit the health endpoint (preferred) or `/` and confirm a 200 response.
+- If there is no health endpoint, add one and redeploy.
+
+## 3) Scan recent error logs
+
+```
+list_logs(resource: ["<service-id>"], level: ["error"], limit: 50)
+```
+
+- If you see a clear error signature, jump to the matching fix in
+  [troubleshooting-basics.md](troubleshooting-basics.md) or
+  [error-patterns.md](error-patterns.md).
+
+## 4) Verify env vars and port binding
+
+- Confirm all required env vars are set (especially secrets marked `sync: false`).
+- Ensure the app binds to `0.0.0.0:$PORT` (not localhost).
+
+## 5) Redeploy only after fixing the first failure
+
+- Avoid repeated deploys without changes; fix one issue at a time.

--- a/skills/render-deploy/references/troubleshooting-basics.md
+++ b/skills/render-deploy/references/troubleshooting-basics.md
@@ -1,0 +1,36 @@
+# Basic troubleshooting (deploy-time and startup)
+
+Use this when a deploy fails, the service crashes on start, or health checks time out.
+Keep fixes minimal and redeploy after each change.
+
+## 1) Classify the failure
+
+- **Build failure**: errors in build logs, missing dependencies, build command issues.
+- **Startup failure**: app exits quickly, crashes, or cannot bind to `$PORT`.
+- **Runtime/health failure**: service is live but health checks fail or 5xx errors.
+
+## 2) Quick checks by class
+
+**Build failure**
+- Confirm the build command is correct for the runtime.
+- Ensure required dependencies are present in `package.json`, `requirements.txt`, etc.
+- Check for missing build-time env vars.
+
+**Startup failure**
+- Confirm the start command and working directory.
+- Ensure port binding is `0.0.0.0:$PORT`.
+- Check for missing runtime env vars (secrets, DB URLs).
+
+**Runtime/health failure**
+- Verify the health endpoint path and response.
+- Confirm the app is actually listening on `$PORT`.
+- Check database connectivity and migrations.
+
+## 3) Map error signatures to fixes
+
+Use [error-patterns.md](error-patterns.md) for a compact catalog of common log messages.
+
+## 4) If still blocked
+
+Gather the latest build logs and runtime error logs, then consider the optional
+`render-debug` skill for deeper diagnostics (metrics, DB checks, expanded patterns).


### PR DESCRIPTION
Add a post‑deploy verification + basic triage loop to render-deploy so the skill is self‑sufficient without relying on render-debug. Introduces three small reference files (post-deploy-checks, troubleshooting-basics, error-patterns) to keep SKILL.md lean while enabling progressive disclosure.