### PR TITLE
Document Render plugin OAuth for the MCP server

### DIFF
--- a/skills/render-debug/SKILL.md
+++ b/skills/render-debug/SKILL.md
@@ -30,7 +30,7 @@ Activate this skill when:
 
 **CLI (fallback):** `render --version` - use if MCP tools unavailable
 
-**Authentication:** For MCP, use an API key (set in the MCP config or via the `RENDER_API_KEY` env var, depending on tool). For CLI, verify with `render whoami -o json`.
+**Authentication:** If you installed the Render plugin (Cursor, Codex, Claude Code), it provides OAuth for MCP — complete the OAuth prompt. For manual MCP clients, use a Render API key. For CLI, verify with `render whoami -o json`.
 
 **Workspace:** `get_selected_workspace()` or `render workspace current -o json`
 
@@ -40,7 +40,9 @@ Activate this skill when:
 
 If `list_services()` fails, set up the Render MCP server. For detailed per-tool walkthroughs, see **render-mcp**.
 
-**Quick setup:** Add the Render MCP server to your AI tool's MCP config:
+**Plugin setup:** If the Render plugin is installed, complete Render OAuth when prompted, then reload your tool and retry `list_services()`.
+
+**Manual MCP setup:** Add the Render MCP server to your AI tool's MCP config:
 - **URL:** `https://mcp.render.com/mcp`
 - **Auth header:** `Authorization: Bearer <YOUR_API_KEY>`
 - **API key:** `https://dashboard.render.com/u/*/settings#api-keys`

--- a/skills/render-deploy/SKILL.md
+++ b/skills/render-deploy/SKILL.md
@@ -115,7 +115,9 @@ If not installed, offer to install:
 
 If `list_services()` fails, set up the Render MCP server. For detailed per-tool walkthroughs, see **render-mcp**.
 
-**Quick setup:** Add the Render MCP server to your AI tool's MCP config:
+**Plugin setup:** If the Render plugin is installed, complete Render OAuth when prompted, then reload your tool and retry `list_services()`.
+
+**Manual MCP setup:** Add the Render MCP server to your AI tool's MCP config:
 - **URL:** `https://mcp.render.com/mcp`
 - **Auth header:** `Authorization: Bearer <YOUR_API_KEY>`
 - **API key:** `https://dashboard.render.com/u/*/settings#api-keys`

--- a/skills/render-mcp/SKILL.md
+++ b/skills/render-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   fails, the user asks about Render MCP setup, or an action skill needs MCP
   but it's not connected yet.
   Trigger terms: MCP, Render MCP, list_services, MCP setup, MCP server,
-  API key, Bearer token, mcp.render.com, workspace selection.
+  OAuth, API key, Bearer token, mcp.render.com, workspace selection.
 license: MIT
 compatibility: Render MCP server (hosted at mcp.render.com)
 metadata:
@@ -36,11 +36,17 @@ Action skills (render-deploy, render-debug, render-monitor) use MCP tools for th
 |----------|-------|
 | URL | `https://mcp.render.com/mcp` |
 | Transport | HTTP (streamable) |
-| Auth | Bearer token (Render API key) |
-| API key page | `https://dashboard.render.com/u/*/settings#api-keys` |
+| Auth | OAuth when installed via the Render plugin (pre-registered client id); bearer token (API key) for manual setup |
+| API key page | `https://dashboard.render.com/u/*/settings#api-keys` (manual setup) |
 | Docs | `https://render.com/docs/mcp-server` |
 
 ## Setup by Tool
+
+### Render plugin (recommended)
+
+The Render plugin for Cursor, Codex, and Claude Code bundles this MCP server with a pre-registered OAuth client id, so no API key is needed. After installing or updating the plugin, reload the tool (restart Cursor or Claude Code, or start a new Codex thread) so it loads the plugin-provided MCP server, then complete the Render OAuth prompt the first time MCP tools are used. Verify with `list_services()`.
+
+The manual, API-key setups below are for tools without the plugin or for custom MCP configurations.
 
 ### Cursor
 
@@ -191,6 +197,8 @@ Optional: `httpLatencyQuantile` (0.5, 0.95, 0.99), `httpPath` (filter by endpoin
 | Mistake | Fix |
 |---------|-----|
 | Wrong URL (using SSE endpoint) | Use `https://mcp.render.com/mcp` (not `/sse`) |
+| Plugin installed but MCP tools unavailable | Reload the tool (restart, or start a new thread) so it loads the plugin's MCP server |
+| OAuth prompt does not appear | Reinstall or update the Render plugin, then reload the tool |
 | Expired or invalid API key | Generate a new key from Dashboard > Account Settings > API Keys |
 | Wrong workspace selected | Run `list_workspaces()` and switch to the correct one |
 | Using MCP to create image-backed services | Not supported — use Dashboard or API for prebuilt Docker images |

--- a/skills/render-mcp/references/troubleshooting.md
+++ b/skills/render-mcp/references/troubleshooting.md
@@ -6,7 +6,7 @@
 
 **Cause:** MCP server not configured in the AI tool.
 
-**Fix:** Follow the setup instructions in the main SKILL.md for your specific tool (Cursor, Claude Code, Codex). After adding the config, restart the tool.
+**Fix:** Follow the setup instructions in the main SKILL.md. If you use the Render plugin, reinstall or update it and reload the tool so it loads the plugin's MCP server. For manual clients, add the config and restart the tool.
 
 ### "Connection refused" or timeout
 
@@ -30,17 +30,17 @@
 
 ### "Unauthorized" or 401
 
-**Cause:** Missing, invalid, or expired API key.
+**Cause:** Missing or expired OAuth authorization (plugin setup), or a missing, invalid, or expired API key (manual setup).
 
 **Fix:**
-1. Generate a new API key: `https://dashboard.render.com/u/*/settings#api-keys`
-2. Update the key in your tool's MCP config
-3. Restart the tool
-4. Verify with `list_services()`
+1. Plugin setup: reinstall or update the Render plugin, then complete the Render OAuth prompt after reloading the tool.
+2. Manual setup: generate a new API key (`https://dashboard.render.com/u/*/settings#api-keys`) and update it in your tool's MCP config.
+3. Restart the tool.
+4. Verify with `list_services()`.
 
 ### "Forbidden" or 403
 
-**Cause:** API key doesn't have access to the requested resource, or wrong workspace.
+**Cause:** OAuth authorization or API key doesn't have access to the requested resource, or wrong workspace.
 
 **Fix:**
 - Check the active workspace with `get_selected_workspace()`
@@ -48,6 +48,8 @@
 - Ensure the API key belongs to an account with access to the workspace
 
 ## Tool-Specific Issues
+
+> Installed the Render plugin? It provides the MCP server over OAuth — complete the Render OAuth prompt and reload the tool after installing or updating the plugin. The manual notes below apply to hand-configured MCP clients.
 
 ### Cursor
 

--- a/skills/render-migrate-from-heroku/references/mcp-setup.md
+++ b/skills/render-migrate-from-heroku/references/mcp-setup.md
@@ -4,12 +4,16 @@ The Render MCP server is recommended for direct service creation and automated v
 
 ## Render MCP Server (Recommended)
 
-Hosted at `https://mcp.render.com/mcp` (recommended, auto-updates). Requires a Render API key from [Account Settings](https://dashboard.render.com/u/*/settings#api-keys).
+Hosted at `https://mcp.render.com/mcp` (recommended, auto-updates). The Render plugin (Cursor, Codex, Claude Code) connects to this server over OAuth with a pre-registered client id — no API key needed. Manual MCP clients can still use a Render API key from [Account Settings](https://dashboard.render.com/u/*/settings#api-keys).
 
 Alternative: run locally via Docker or binary (see [Render MCP docs](https://render.com/docs/mcp-server)).
 Source: [render-mcp-server](https://github.com/render-oss/render-mcp-server)
 
 **Detecting the user's tool:** Infer the AI tool from this skill's install path (`~/.cursor/skills/` = Cursor, `~/.claude/skills/` = Claude Code, `~/.codex/skills/` = Codex). If the path doesn't match a known tool, ask the user which tool they're using, then follow the matching section below.
+
+### Render plugin (recommended)
+
+If the Render plugin is installed for your tool, it already declares this MCP server with a pre-registered OAuth client id. Reload the tool (restart Cursor or Claude Code, or start a new Codex thread), complete the Render OAuth prompt when asked, then retry `list_services()`. The manual, API-key setups below are for tools without the plugin.
 
 ### Cursor
 
@@ -99,4 +103,4 @@ After configuring, test your connections:
 - Ask: "List my Render services" — should return services via Render MCP (required)
 - Ask: "List my Heroku apps" — should return apps via Heroku MCP (optional)
 
-If Render MCP fails, check your API key and restart your MCP client. If Heroku MCP is not configured, the migration skill still works — it reads local project files and asks you to provide config var values manually.
+If Render MCP fails, reinstall or update the Render plugin and reload the tool (plugin setup), or check your API key and restart your MCP client (manual setup). If Heroku MCP is not configured, the migration skill still works — it reads local project files and asks you to provide config var values manually.

--- a/skills/render-monitor/SKILL.md
+++ b/skills/render-monitor/SKILL.md
@@ -29,7 +29,7 @@ Activate this skill when users want to:
 
 **CLI (fallback):** `render --version` - use if MCP tools unavailable
 
-**Authentication:** For MCP, use an API key (set in the MCP config or via the `RENDER_API_KEY` env var, depending on tool). For CLI, verify with `render whoami -o json`.
+**Authentication:** If you installed the Render plugin (Cursor, Codex, Claude Code), it provides OAuth for MCP — complete the OAuth prompt. For manual MCP clients, use a Render API key. For CLI, verify with `render whoami -o json`.
 
 **Workspace:** `get_selected_workspace()` or `render workspace current -o json`
 
@@ -39,7 +39,9 @@ Activate this skill when users want to:
 
 If `list_services()` fails, set up the Render MCP server. For detailed per-tool walkthroughs, see **render-mcp**.
 
-**Quick setup:** Add the Render MCP server to your AI tool's MCP config:
+**Plugin setup:** If the Render plugin is installed, complete Render OAuth when prompted, then reload your tool and retry `list_services()`.
+
+**Manual MCP setup:** Add the Render MCP server to your AI tool's MCP config:
 - **URL:** `https://mcp.render.com/mcp`
 - **Auth header:** `Authorization: Bearer <YOUR_API_KEY>`
 - **API key:** `https://dashboard.render.com/u/*/settings#api-keys`


### PR DESCRIPTION
Document the Render plugins' OAuth connection to the MCP server in the shared skills.

- render-mcp (SKILL + troubleshooting), render-debug, render-deploy, render-monitor, and render-migrate-from-heroku now describe the plugin OAuth path, keeping API-key setup for manual clients.
- Wording is tool-agnostic so it reads correctly for every plugin.